### PR TITLE
ユーザー情報を確認画面で登録しないように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@
 !/tmp/storage/.keep
 
 /public/assets
+/app/assets/images
+!/app/assets/images/default_profile.png
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/app/controllers/line_auth_controller.rb
+++ b/app/controllers/line_auth_controller.rb
@@ -1,5 +1,6 @@
 class LineAuthController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [ :callback ]
+  TMP_USER_IMAGE_PATH = "app/assets/images"
 
   def callback
     auth = request.env["omniauth.auth"]  # LINEからの認証情報を取得
@@ -7,10 +8,8 @@ class LineAuthController < ApplicationController
     @user.name = auth["info"]["name"]
     @user.line_user_id = auth["uid"]
     @user.provider = auth["provider"]
-    image_file_path = image(auth, @user.id)
-    # ユーザーをログイン状態にする
-    session[:@user_id] = @user.id
-    redirect_to new_registrations_path(user_id: @user.id, user_name: @user.name, user_uid: @user.line_user_id, user_provider: @user.provider, image_file_path: image_file_path)
+    @user.tmp_profile_file_path = image(auth, @user.line_user_id)
+    redirect_to new_registrations_path(name: @user.name, line_user_id: @user.line_user_id, provider: @user.provider, tmp_profile_file_path: @user.tmp_profile_file_path)
   end
 
   def failure
@@ -18,7 +17,7 @@ class LineAuthController < ApplicationController
     redirect_to root_path, alert: "LINE認証に失敗しました"
   end
 
-  def image(auth, user_id)
+  def image(auth, line_user_id)
     # LINEから画像URLを取得して一時ファイルとして保存
     if auth["info"]["image"].present?
       begin
@@ -30,19 +29,8 @@ class LineAuthController < ApplicationController
         # LINEから画像URLが取得できない場合はデフォルト画像を設定
         image_file = File.open(Rails.root.join("app/assets/images/default_profile.png"))
     end
-    file_path = Rails.root.join("tmp", user_id.to_s)
+    file_path = Rails.root.join(TMP_USER_IMAGE_PATH, "#{line_user_id}.jpg")
     File.open(file_path, "wb") { |f| f.write(image_file) }
     file_path
   end
-
-  # def process
-  #   temp_image_path = params[:temp_image_path]
-  #   if temp_image_path && File.exist?(temp_image_path)
-  #     # 画像を処理
-  #     File.delete(temp_image_path) # 処理後に一時ファイルを削除
-  #   else
-  #     flash[:alert] = "画像ファイルが見つかりません。"
-  #     redirect_to new_upload_path
-  #   end
-  # end
 end

--- a/app/controllers/line_auth_controller.rb
+++ b/app/controllers/line_auth_controller.rb
@@ -3,30 +3,46 @@ class LineAuthController < ApplicationController
 
   def callback
     auth = request.env["omniauth.auth"]  # LINEからの認証情報を取得
-    user = User.find_or_initialize_by(uid: auth["uid"], provider: auth["provider"])
-    user.name = auth["info"]["name"]
-    user.line_user_id = auth["uid"]
-    user.provider = auth["provider"]
-    # LINEから画像URLを取得してローカルに保存
-    if auth["info"]["image"].present?
-      begin
-        image_file = URI.open(auth["info"]["image"]) # LINEの画像URLから取得
-        user.profile_image.attach(io: image_file, filename: "profile_#{user.id}.jpg", content_type: "image/jpeg")
-      rescue => e
-        Rails.logger.error "プロフィール画像取得エラー: #{e.message}"
-      end
-    else
-      # LINEから画像URLが取得できない場合はデフォルト画像を設定
-      user.profile_image.attach(io: File.open(Rails.root.join("app/assets/images/default_profile.png")), filename: "default.jpg", content_type: "image/jpeg")
-    end
-    user.save!
+    @user = User.find_or_initialize_by(uid: auth["uid"], provider: auth["provider"])
+    @user.name = auth["info"]["name"]
+    @user.line_user_id = auth["uid"]
+    @user.provider = auth["provider"]
+    image_file_path = image(auth, @user.id)
     # ユーザーをログイン状態にする
-    session[:user_id] = user.id
-    redirect_to new_registrations_path
+    session[:@user_id] = @user.id
+    redirect_to new_registrations_path(user_id: @user.id, user_name: @user.name, user_uid: @user.line_user_id, user_provider: @user.provider, image_file_path: image_file_path)
   end
 
   def failure
     Rails.logger.error "LINE認証エラー: #{e.message}"
     redirect_to root_path, alert: "LINE認証に失敗しました"
   end
+
+  def image(auth, user_id)
+    # LINEから画像URLを取得して一時ファイルとして保存
+    if auth["info"]["image"].present?
+      begin
+        image_file = URI.open(auth["info"]["image"]) # LINEの画像URLから取得
+      rescue => e
+        Rails.logger.error "プロフィール画像取得エラー: #{e.message}"
+      end
+    else
+        # LINEから画像URLが取得できない場合はデフォルト画像を設定
+        image_file = File.open(Rails.root.join("app/assets/images/default_profile.png"))
+    end
+    file_path = Rails.root.join("tmp", user_id.to_s)
+    File.open(file_path, "wb") { |f| f.write(image_file) }
+    file_path
+  end
+
+  # def process
+  #   temp_image_path = params[:temp_image_path]
+  #   if temp_image_path && File.exist?(temp_image_path)
+  #     # 画像を処理
+  #     File.delete(temp_image_path) # 処理後に一時ファイルを削除
+  #   else
+  #     flash[:alert] = "画像ファイルが見つかりません。"
+  #     redirect_to new_upload_path
+  #   end
+  # end
 end

--- a/app/controllers/line_auth_controller.rb
+++ b/app/controllers/line_auth_controller.rb
@@ -12,11 +12,6 @@ class LineAuthController < ApplicationController
     redirect_to new_registrations_path(name: @user.name, line_user_id: @user.line_user_id, provider: @user.provider, tmp_profile_file_path: @user.tmp_profile_file_path)
   end
 
-  def failure
-    Rails.logger.error "LINE認証エラー: #{e.message}"
-    redirect_to root_path, alert: "LINE認証に失敗しました"
-  end
-
   def image(auth, line_user_id)
     # LINEから画像URLを取得して一時ファイルとして保存
     if auth["info"]["image"].present?
@@ -32,5 +27,10 @@ class LineAuthController < ApplicationController
     file_path = Rails.root.join(TMP_USER_IMAGE_PATH, "#{line_user_id}.jpg")
     File.open(file_path, "wb") { |f| f.write(image_file) }
     file_path
+  end
+
+  def failure
+    Rails.logger.error "LINE認証エラー: #{e.message}"
+    redirect_to root_path, alert: "LINE認証に失敗しました"
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,10 +1,12 @@
 class RegistrationsController < ApplicationController
-  def new
+  before_action :set_user
+
+  def new(user)
     # 新規登録画面表示
     @user = User.find(session[:user_id])
   end
 
-  def confirm
+  def confirm(user)
     # 入力内容確認画面表示
     @user = User.find(session[:user_id])
     @year = params[:year]
@@ -14,5 +16,19 @@ class RegistrationsController < ApplicationController
 
   def complete
     # 登録完了画面表示
+    #
+    # Active record登録用コード備忘
+    # @user.profile_image.attach(io: image_file, filename: "profile_#{@user.id}.jpg", content_type: "image/jpeg")
+    #
+  end
+
+  private
+  def set_user
+    @user = User.new(
+      params[:user_id],
+      params[:user_name],
+      params[:user_uid],
+      params[:user_provider]
+    )
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,14 +1,15 @@
 class RegistrationsController < ApplicationController
-  before_action :set_user
+  # before_action :user_params
 
-  def new(user)
+  def new
     # 新規登録画面表示
-    @user = User.find(session[:user_id])
+    @user = User.new(name: params[:name], line_user_id: params[:line_user_id], provider: params[:provider], tmp_profile_file_path: params[:tmp_profile_file_path])
   end
 
-  def confirm(user)
+  def confirm
     # 入力内容確認画面表示
-    @user = User.find(session[:user_id])
+    @user = User.new(name: params[:name], line_user_id: params[:line_user_id], provider: params[:provider], tmp_profile_file_path: params[:tmp_profile_file_path])
+    # @user = User.find(session[:user_id])
     @year = params[:year]
     @month = params[:month]
     @day = params[:day]
@@ -19,16 +20,10 @@ class RegistrationsController < ApplicationController
     #
     # Active record登録用コード備忘
     # @user.profile_image.attach(io: image_file, filename: "profile_#{@user.id}.jpg", content_type: "image/jpeg")
-    #
   end
 
   private
-  def set_user
-    @user = User.new(
-      params[:user_id],
-      params[:user_name],
-      params[:user_uid],
-      params[:user_provider]
-    )
+  def user_params
+    params.require(:user).permit(:name, :line_user_id, :provider, :tmp_profile_file_path)
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,6 @@ class RegistrationsController < ApplicationController
   def confirm
     # 入力内容確認画面表示
     @user = User.new(name: params[:name], line_user_id: params[:line_user_id], provider: params[:provider], tmp_profile_file_path: params[:tmp_profile_file_path])
-    # @user = User.find(session[:user_id])
     @year = params[:year]
     @month = params[:month]
     @day = params[:day]
@@ -17,9 +16,6 @@ class RegistrationsController < ApplicationController
 
   def complete
     # 登録完了画面表示
-    #
-    # Active record登録用コード備忘
-    # @user.profile_image.attach(io: image_file, filename: "profile_#{@user.id}.jpg", content_type: "image/jpeg")
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+    # 登録前の一時的なプロフィール画像のファイルパスを保持
+    attr_accessor :tmp_profile_file_path, :tmp_profile_file
+
     # 申請状態関係
     has_many :sent_requests, class_name: "Request", foreign_key: "sender_id", dependent: :destroy
     has_many :received_requests, class_name: "Request", foreign_key: "receiver_id", dependent: :destroy

--- a/app/views/registrations/confirm.html.erb
+++ b/app/views/registrations/confirm.html.erb
@@ -2,7 +2,7 @@
     <h1>確認</h1>
     <div class="user-info">
         <span class="user-image">
-            <%= @user.profile_image.attached? ? image_tag(url_for(@user.profile_image), alt: "User Profile Image") : "画像を取得できませんでした, URL: #{@user.profile_image}, 添付？：#{@user.profile_image.attached?}" %>
+            <%= image_tag("#{@user.tmp_profile_file_path}") %>
         </span>
         <span class="user-name">
             <%= @user.name%>
@@ -20,6 +20,6 @@
             <%= @day %>日
         </span>
     </div>        
-    <%= button_to "登録", confirm_registrations_path, method: :post, class: "btn-confirm", data: { turbo: true } %>
-    <%= button_to "戻る", confirm_registrations_path, method: :get, class: "btn-return", data: { turbo: true } %>
+    <%= button_to "登録", confirm_registrations_path(name: @user.name, year: @year, month: @month, day: @day), method: :post, class: "btn-confirm" %>
+    <%= button_to "戻る", confirm_registrations_path, method: :get, class: "btn-return" %>
 </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -2,7 +2,7 @@
     <h1>新規登録</h1>
     <div class="user-info">
         <span class="user-image">
-            <%= @user.profile_image.attached? ? image_tag(url_for(@user.profile_image), alt: "User Profile Image") : "画像を取得できませんでした, URL: #{@user.profile_image}, 添付？：#{@user.profile_image.attached?}" %>
+            <%= image_tag("#{@user.tmp_profile_file_path}") %>
         </span>
         <span class="user-name">
             <%= @user.name%>
@@ -10,7 +10,13 @@
     </div>
     <div class="user-input"> 
         <p>生年月日</p>
-        <%= form_with url: confirm_registrations_path, method: :get, data: { turbo: true } do |form| %>
+        <%= form_with url: confirm_registrations_path, method: :get do |form| %>
+            <span>
+                <%= form.hidden_field :line_user_id, value: @user.line_user_id %>
+                <%= form.hidden_field :name, value: @user.name %>
+                <%= form.hidden_field :provider, value: @user.provider %>
+                <%= form.hidden_field :tmp_profile_file_path, value: @user.tmp_profile_file_path %>
+            </span>
             <div>
                 <%= form.number_field :year, required: true, placeholder: "1990", min: 1990, max: 2999, class: "input" %> 年
                 <%= form.number_field :month, required: true, placeholder: "10"  , min: 1, max: 12, class: "input"  %> 月


### PR DESCRIPTION
##　修正目的
元々LINE認証情報のコールバックアクション内でユーザー情報をテーブルに仮ユーザーとして登録していたが、登録確認前に登録するのはまずいため。

### 修正前
LINE認証のコールバックアクション内でユーザー情報を登録していた。

### 修正後
LINE認証のコールバックアクション内では登録せずに、ユーザー情報をクエリパラメーターとして渡すように修正した。

